### PR TITLE
Added microhook-below-wrapper.html microhook

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -54,8 +54,11 @@
       </ul>
     </nav>
   </header>
-  <div class="page-content">
+  <div class="page-content-wrapper">
+    <div class="page-content">
       {{ block "main" . }}{{ end }}
+    </div>
+    {{ if templates.Exists "partials/microhook-below-wrapper.html" }}{{ partial "microhook-below-wrapper.html" . }}{{ end }}
   </div>
   <footer class="site-footer">
 


### PR DESCRIPTION
Hi @MattSLangford,

I hope you don't mind but I've seen a few people on Micro.blog asking about a sidebar for Bayou, so I took the liberty of starting to work on one.

While developing it, I found that I had to make a few small changes to the baseof template, so I was wondering if we could do something similar to what we did for Tiny Theme, in that we added a new microhook that would appear just below the main content.

I've raised this MR which would do just that. This new `microhook-below-wrapper.html` microhook will appear below the main content, which is now wrapped in a `<div class="page-content-wrapper">` to facilitate styling of the sidebar.

You can see how this looks by checking out this test site: https://lmika-test.micro.blog. (note that I copied and pasted the changes to Micro.blog's theme designer as I don't know if pulling from a Github branch works).

Let me know if you'd like me to change anything about this.

Thanks,

Leon